### PR TITLE
Feature 166704957 support arbitrary version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ add a config file to your project that has contents similar to:
 		API_PASSWORD: 'secret',
 		PRIVATE_KEY:  'secret',
 		SUBDOMAIN:    '[your_account]',
-		VERSION:      '2',
+		API_VERSION:  '2.7',
 		DEBUG:        false
 	};
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -20,7 +20,8 @@ exports.create = function(config){
         headers: {
           Authorization: "Basic "+(new Buffer(config.API_USERNAME+":"+config.API_PASSWORD)).toString('base64'),
           Accept: 'application/xml',
-          'Content-Length' : (data) ? Buffer.byteLength(data) : 0
+          'Content-Length' : (data) ? Buffer.byteLength(data) : 0,
+          'X-Api-Version': config.API_VERSION
         }
       };
 

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -5,7 +5,7 @@
       router = require('./routes/');
 
   module.exports = function(config){
-		var routes = router.routes(config.API_VERSION);
+		var routes = router.routes(config.API_VERSION.toString().split('.')[0]);
 		var t = Client.create(config);
 
 		//http://docs.recurly.com/api/accounts

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "node": ">= 0.4"
   },
   "devDependencies": {
-    "mocha": "~1.12.0",
-    "nock": "~0.18.2",
-    "chai": "~1.7.2"
+    "chai": "1.7.2",
+    "debug": "1.0.0",
+    "mocha": "1.12.0",
+    "nock": "0.18.2"
   },
   "scripts": {
     "test": "node_modules/mocha/bin/mocha"


### PR DESCRIPTION
@sohlhausen 

Recurly now requires us to send a `X-Api-Version` request header when hitting their API. It indicates the major/minor version of the API we're targeting. We must target 2.7 or above by November.

I changed the expectation of `API_VERSION` from being just `2` to being something like `"2.7"`. I grepped for usages of `API_VERSION` and updated the affected areas.

The version of `mocha` we were using here has a dev dependency of `debug: '*'` which otherwise grabs the latest version, which uses ES6 and such. I pegged a version from back in the day that works fine on node 0.10.

I have a branch that uses this version of `node-recurly` and it seems to work fine.

cc @nanek 